### PR TITLE
using functions to understand the definitions of alias when executing…

### DIFF
--- a/.config/zsh/alias_exports.sh
+++ b/.config/zsh/alias_exports.sh
@@ -51,11 +51,13 @@ esac
 # https://www.youtube.com/watch?v=tBoLDpTWVOM
 # https://www.atlassian.com/git/tutorials/dotfiles
 # make sure you have -> git init --bare $HOME/dotfiles
-alias config='git --git-dir=$HOME/dotfiles --work-tree=$HOME'
+# alias config='git --git-dir=$HOME/dotfiles --work-tree=$HOME'
+# see functions.sh
 # then -> config config --local status.showUntrackedFiles no
 
 # /etc managed by git
-alias etc='sudo git --git-dir=/etc/.git --work-tree=/etc'
+#alias etc='sudo git --git-dir=/etc/.git --work-tree=/etc'
+# see functions.sh
 
 # ~/notes managed by git
 # see functions.sh

--- a/.config/zsh/functions.sh
+++ b/.config/zsh/functions.sh
@@ -284,11 +284,59 @@ function gm2() {
 
 function notes() {
     if [[ "$#" == 0 ]]; then
-        vscodium ~/notes
+        # see code alias in alias_exports.sh
+        code ~/notes
         return
     fi
-    echo -e "Executing git command in notes repo ${YELLOW} $@ ${NC}"
-    git --git-dir=$HOME/notes/.git --work-tree=$HOME/notes $@
+    command_to_execute="$@"
+    echo -e "Executing command in notes repo ${YELLOW} $command_to_execute ${NC}"
+    #git --git-dir=$HOME/notes/.git --work-tree=$HOME/notes $@
+    bash -i -c "cd '$HOME/notes' && source ~/.bashrc && $command_to_execute"
+}
+
+
+function etc() {
+    # https://unix.stackexchange.com/questions/91384/how-is-sudo-set-to-not-change-home-in-ubuntu-and-how-to-disable-this-behavior
+    # Requires config changes to sudo in order preserver $HOME
+    # sudo visudo
+    #   -# Defaults env_keep += "HOME"
+    #   +Defaults env_keep += "HOME"
+    #
+    if [[ "$#" == 0 ]]; then
+        cd /etc
+        return
+    fi
+    command_to_execute="$@"
+    my_home="$HOME"
+    echo -e "Executing command in etc repo ${YELLOW} $command_to_execute ${NC}"
+    #git --git-dir=/etc/.git --work-tree=/etc $@
+    sudo bash -i -c "cd /etc && source $my_home/.bashrc && $command_to_execute"
+}
+
+
+function config() {
+    if [[ "$#" == 0 ]]; then
+        # see code alias in alias_exports.sh
+        code ~/
+        return
+    fi
+    command_to_execute="$@"
+    echo -e "Executing command in config repo ${YELLOW} $command_to_execute ${NC}"
+    #git --git-dir=$HOME/notes/.git --work-tree=$HOME/notes $@
+    bash -i -c "cd ~ && source ~/.bashrc && $command_to_execute"
+}
+
+
+function config_private() {
+    if [[ "$#" == 0 ]]; then
+        # see code alias in alias_exports.sh
+        code ~/.config/private
+        return
+    fi
+    command_to_execute="$@"
+    echo -e "Executing command in private('$HOME/.config/private') repo ${YELLOW} $command_to_execute ${NC}"
+    #git --git-dir=$HOME/notes/.git --work-tree=$HOME/notes $@
+    bash -i -c "cd ~/.config/private && source ~/.bashrc && $command_to_execute"
 }
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,24 @@
 
 <h4 align="center"> DotFiles are meant to be copied!</h4>
 
-##### 1 - Deploying with git bare repo
+##### 1 - Deploying with git
 
+```
+git clone git@github.com:abassel/dotfiles.git
+cp -R dotfiles/.git ~/.git
+cd ~
+git config --local status.showUntrackedFiles no
+git diff
+git checkout
+<OPEN AND CLOSE TERMINAL>
+# config <COMMAND>
+# ex:
+config git status
+config git diff
+```
+
+
+##### 2 - ~~Deploying with git bare repo~~(OUTDATED)
 ```
 
 alias config='git --git-dir=$HOME/dotfiles --work-tree=$HOME'


### PR DESCRIPTION
… config/etc/notes commands

in the past a command like `config gl` would not work since gl and config are both alias now with config as a function that changes to the directory and executes the command loading all the definitions it will work